### PR TITLE
src/Makefile.am: Link with math for round() dependency.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,4 +27,4 @@ depth_file_viewer_SOURCES = \
 	depth-file-viewer.c
 
 depth_file_viewer_LDADD = \
-	$(MAIN_DEPS_LIBS)
+	$(MAIN_DEPS_LIBS) -lm


### PR DESCRIPTION
Fix the linking error below: 

/usr/bin/ld: depth-file-viewer.o: undefined reference to symbol 'round@@GLIBC_2.2.5'
/usr/bin/ld: note: 'round@@GLIBC_2.2.5' is defined in DSO /lib64/libm.so.6 so try adding it to the linker command line
